### PR TITLE
Fixed empty tab backgrounds, Fixed tab icon colors

### DIFF
--- a/css/gmail.css
+++ b/css/gmail.css
@@ -688,12 +688,21 @@
         background: var(--GR3) !important;
         color: var(--GR14) !important;
     }
+    /* Empty tab background */
+    .aRs {
+        background: var(--GR1) !important;
+    }
 
     /* Toolbar */
 
         /* Separators */
         .G-Ni.G-aE:not(:first-child) {box-shadow: inset -1px 0 0 hsla(211, 18%, 88%, .122) !important }
 
+	/* Tab Icons */
+        .aIf-aLf, .aJi-aLf, .aKe-aLf, .aH2-aLf {
+           filter: invert(76%) sepia(8%) saturate(153%) hue-rotate(159deg) brightness(96%) contrast(86%);
+        }
+	
     /* Row */
     .yO {
         background: var(--GR4) !important;


### PR DESCRIPTION
Fixed the background of tabs with no email entries.
Changed the color of tab icons by using [MultiplyByZer0](https://stackoverflow.com/questions/42966641/how-to-transform-black-into-any-given-color-using-only-css-filters/43960991#43960991)'s method and Barrett Sonntag's [tool](https://codepen.io/sosuke/pen/Pjoqqp) for filter-based PGN color shift.

### Before:
![image](https://user-images.githubusercontent.com/19366911/188394229-7f903f90-8102-44a8-b06d-08b7ea904f48.png)

### After:
![image](https://user-images.githubusercontent.com/19366911/188394265-96dc1e9b-ba36-4550-a8e0-5e2ae98622d0.png)

CSS rules may not be categorized as intended, move them as needed.

