### PR TITLE
Joeyrsp fix all day arrows + dim past events

### DIFF
--- a/css/calendar.user.css
+++ b/css/calendar.user.css
@@ -396,6 +396,11 @@
 			
 	/* DAY/WEEK/4-DAY VIEW */
 
+		/* Time Event (Past) */
+		.afiDFd.UflSff {
+			filter: brightness(0.6) contrast(1.5) !important;
+		}
+
 		/* Time Event (Past) Full Day With Overflow */
 		.g3dbUc.UflSff:is(.JRw8kf, .XFPdgf) {
 			overflow: visible !important;

--- a/css/calendar.user.css
+++ b/css/calendar.user.css
@@ -394,6 +394,18 @@
 			/* Color Box Center */
 			.uHMk6b { border-color: var(--GR2) !important }
 			
+	/* DAY/WEEK/4-DAY VIEW */
+
+		/* Time Event (Past) Full Day With Overflow */
+		.g3dbUc.UflSff:is(.JRw8kf, .XFPdgf) {
+			overflow: visible !important;
+		}
+
+			/* Arrow */
+			.zWcBU.BvHyo.gpOGPc {
+				translate: calc(1px + 100%) -1px !important;
+			}
+
 	/* DAY VIEW */
 	
 		/* Body */

--- a/css/calendar.user.css
+++ b/css/calendar.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           Google Calendar Redesigned (Dark Mode)
 @namespace      Globex Designs, Inc.
-@version        20230225.0.0
+@version        20230316.0.0
 @homepageURL    https://github.com/EvHaus/google-redesigned
 @updateURL      https://raw.githubusercontent.com/EvHaus/google-redesigned/master/css/calendar.user.css
 @license        CC-BY-4.0


### PR DESCRIPTION
I've only tested the fix on firefox.

I applied the same dim filter to the time events as the all day but with a contrast boost because i found it got a bit too muddy.